### PR TITLE
Fix count discrepancy between import and search

### DIFF
--- a/app/assets/javascripts/fda_labels.js
+++ b/app/assets/javascripts/fda_labels.js
@@ -19,7 +19,8 @@ window.FDA.Labels = (function($, Handlebars) {
     var pageNumber = 1;
     if(options && options.page) pageNumber = options.page;
     $.get(apiRoot + "?search=(_exists_:openfda.brand_name+AND+" +
-      "openfda.substance_name:" + ingredientName +")" +
+      "openfda.substance_name.exact:\"" + ingredientName.replace(/ /g, "+") +
+      "\")" +
       "&limit=" + defaultPerPage +
       "&skip=" + (pageNumber-1) * defaultPerPage)
       .done(function(data) {


### PR DESCRIPTION
add .exact to the search parameters when fetching data from the openFDA
API.  Leaving this off was causing multi-word substance names to be
tokenized in the search.  For example, searching for "Titanium Dioxide"
would bring back all results that had "Titanium" or "Dioxide" in the
name.

Replace spaces with + per API Docs

Per the API documentation, spaces in the search terms should be replaced
with "+"
