### PR TITLE
Truncate active ingredients list

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -331,6 +331,3 @@ DEPENDENCIES
   sqlite3
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
-
-BUNDLED WITH
-   1.10.4

--- a/app/assets/javascripts/autocomplete.js
+++ b/app/assets/javascripts/autocomplete.js
@@ -12,6 +12,11 @@ $(function () {
     FDA.Labels.findWithIngredient(substance);
   })
 
+  $("#items").on("click", ".show-more-ingredients", function(e) {
+    $(this).siblings(".hidden-ingredients").removeClass("hidden");
+    $(this).hide();
+  });
+
   function autocompleteFormat(data) {
     return $.map(data.results, function (val) {
       return {

--- a/app/assets/javascripts/fda_labels.js
+++ b/app/assets/javascripts/fda_labels.js
@@ -10,6 +10,10 @@ window.FDA.Labels = (function($, Handlebars) {
   }
 
   function populateLabelGrid(data) {
+    /* Sort the active ingredients alphabetially here so we don't have to in handlebars */
+    $.each(data.results, function(index, drug) {
+      drug.openfda.substance_name.sort();
+    });
     var labelTemplate = getTemplate("labels");
     $("#items").html(labelTemplate(data));
   }
@@ -136,4 +140,19 @@ Handlebars.registerHelper('grouped_each', function(every, context, options) {
         out += options.fn(subcontext);
     }
     return out;
+});
+
+Handlebars.registerHelper('slice', function(from, to, context, options) {
+  var ret = "";
+  if(to == 0) to = context.length - 1;
+  for(i = from; i <= to; i++) {
+    ret = ret + options.fn(context[i]);
+  }
+  return ret;
+});
+
+Handlebars.registerHelper('ifMoreItems', function(moreThan, context, options){
+  if(context.length > moreThan) {
+    return options.fn(this);
+  }
 });

--- a/app/views/visitors/ingredient_browser.html.erb
+++ b/app/views/visitors/ingredient_browser.html.erb
@@ -67,14 +67,27 @@
         </div>
         <div class="active-ingredients">
           <h4 class="active-ingredients-header">Active Ingredients</h4>
-          {{#each openfda.substance_name}}
+          {{#slice 0 4 openfda.substance_name}}
             <div class="active-ingredient">
               <a href="#ingredient-search" class="substance"
                 data-substance="{{this}}">
                 {{this}}
               </a>
             </div>
-          {{/each}}
+          {{/slice}}
+          {{#ifMoreItems 5 openfda.substance_name}}
+            <div class="hidden-ingredients hidden">
+            {{#slice 5 0 openfda.substance_name}}
+              <div class="active-ingredient">
+                <a href="#ingredient-search" class="substance"
+                  data-substance="{{this}}">
+                  {{this}}
+                </a>
+              </div>
+            {{/slice}}
+            </div>
+            <a href="javascript: void(0);" class="show-more-ingredients">Show more...</a>
+          {{/ifMoreItems}}
         </div>
       </div>
     {{/each}}


### PR DESCRIPTION
If a drug has more than 5 active ingredients, only show the first 5 and
add a link to show the rest.
