### PR TITLE
Jump to results after populating the results grid

### DIFF
--- a/app/assets/javascripts/fda_labels.js
+++ b/app/assets/javascripts/fda_labels.js
@@ -12,6 +12,7 @@ window.FDA.Labels = (function($, Handlebars) {
   function populateLabelGrid(data) {
     var labelTemplate = getTemplate("labels");
     $("#items").html(labelTemplate(data));
+    $("html, body").scrollTop($("#ingredient-search").offset().top);
   }
 
   // Public functions


### PR DESCRIPTION
Scroll to the #ingredient-search anchor when results are displayed.  This works for both clicking on the visualization and the autocomplete.
